### PR TITLE
Improve instructions for the initial setup

### DIFF
--- a/app/README.rst
+++ b/app/README.rst
@@ -30,7 +30,7 @@ There are three great tools for python development:
 
     brew install mysql
     mysql --version
-    (mysql  Ver 14.14 Distrib 5.6.23, for osx10.9 (x86_64) using  EditLine wrapper)
+    (mysql  Ver 14.14 Distrib 5.6.24, for osx10.9 (x86_64) using  EditLine wrapper)
 
     sudo pip install virtualenv
     sudo pip install virtualenvwrapper
@@ -44,7 +44,23 @@ There are three great tools for python development:
     workon redi-dropper-client
     cd ~/git/redi-dropper-client/app
     fab install_requirements
-    fab reset_db
+    fab init_db
+
+    # create/update important configuration params
+    cp redidropper/startup/application.cfg.example ~/redidropper_application.cfg
+
+    # run the application
+    REDIDROPPER_CONFIG=~/redidropper_application.cfg python run.py
+
+    # to avoid typing the REDIDROPPER_CONFIG=... you can create a permanent
+    # environment entry in your ~/.bashrc
+    echo 'REDIDROPPER_CONFIG=~/redidropper_application.cfg' >> ~/.bashrc && . ~/.bashrc
+    # ... and then you can simply run
+    ./run.sh
+        or
+    python run.py
+
+
 
 Files & Folders
 ---------------

--- a/app/README.rst
+++ b/app/README.rst
@@ -60,7 +60,8 @@ There are three great tools for python development:
         or
     python run.py
 
-
+    Finally you can opn your browser at https://localhost:5000/ and login as 
+    admin@example.com with any password
 
 Files & Folders
 ---------------

--- a/app/fabfile.py
+++ b/app/fabfile.py
@@ -29,6 +29,22 @@ def install_requirements():
 
 
 @task
+def initdb():
+    init_db()
+
+@task
+def init_db():
+    """
+
+    """
+    if not confirm("Do you want to create the RediDropper database tables?"):
+        abort("Aborting at user request.")
+    local('sudo mysql < db/001/upgrade.sql')
+    local('sudo mysql < db/002/upgrade.sql')
+    local('sudo mysql < db/002/data.sql')
+
+
+@task
 def resetdb():
     reset_db()
 


### PR DESCRIPTION
`fab init_db` creates the fresh database, after that developers can run `fab reset_db`