### PR TITLE
Change Menu button on navigation bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [0.0.3b] - 2015-08-31
+
+### Changed
+* Add option for accepting parent repo path (Ruchi Vivek Desai)
+* Restore click functionality for main page "getting started" (Andrei Sura)
+* Simplify sample.virtualhost.conf used on prod (Andrei Sura)
+
+
 ## [0.0.3a] - 2015-08-27
 ### Added
 * Add sample config files for deploying two application instances 

--- a/app/redidropper/static/css/parallax.css
+++ b/app/redidropper/static/css/parallax.css
@@ -141,3 +141,34 @@ This stylesheet and the associated (x)html may be modified in any way to fit you
 #support button {
   color: #FFFFFF;
 }
+
+/*So that all content and icon is visible on smaller screens*/
+@media all and (max-width: 1000px) {
+  #home {
+    height: 600px;
+  }
+  #about {
+    height: 600px;
+  }
+  #information {
+    height: 600px;
+  }
+  #services {
+    height: 600px;
+  }
+  #gettingstarted {
+    height: 600px;
+  }
+  #faq {
+    height: 600px;
+  }
+  #support {
+    height: 600px;
+  }
+  #image2 {
+    height: 600px;
+  }
+  #image3 {
+    height: 600px;
+  }
+}

--- a/app/redidropper/static/js/sidebar.js
+++ b/app/redidropper/static/js/sidebar.js
@@ -5,8 +5,8 @@ $(document).ready(function() {
         $("#wrapper").toggleClass("toggled");
         var icon = $(this).parent().find(".fa")
         if (icon.hasClass('fa-angle-left'))
-            icon.removeClass('fa-angle-left').addClass("fa-angle-right");
+            icon.removeClass('fa-angle-left').addClass("fa-bars");
         else
-            icon.removeClass('fa-angle-right').addClass("fa-angle-left");
+            icon.removeClass('fa-bars').addClass("fa-angle-left");
     });
 });


### PR DESCRIPTION
1. Changed menu button on navigation bar from > icon to menu icon.

2. Made the page responsive:
 - When we reduce the size of the browser window, the icons on the Services section were getting hidden due to the section width being based on the viewport height. Fixed this to make it responsive.
 - Still need to fix the scenario where, on reducing browser window size, the menu icon transition gets reversed:

Correct:
<img width="1110" alt="screen shot 2015-09-09 at 10 43 28 am" src="https://cloud.githubusercontent.com/assets/6810452/9764989/e6f6d19c-56df-11e5-9a79-e90bab97c96b.png">
<img width="985" alt="screen shot 2015-09-09 at 10 43 50 am" src="https://cloud.githubusercontent.com/assets/6810452/9764996/ec86615e-56df-11e5-80dd-805d8aea9e3f.png">

Incorrect:
<img width="537" alt="screen shot 2015-09-09 at 10 44 03 am" src="https://cloud.githubusercontent.com/assets/6810452/9764999/ef6ba230-56df-11e5-90ae-d6a1f85c7e29.png">
<img width="529" alt="screen shot 2015-09-09 at 10 44 14 am" src="https://cloud.githubusercontent.com/assets/6810452/9765001/f1b292ec-56df-11e5-8626-c8a3a5eaa590.png">
