### PR TITLE
addressing issue #136 to increase the file upload max size to 3gb inst…

### DIFF
--- a/app/redidropper/static/js/utils.js
+++ b/app/redidropper/static/js/utils.js
@@ -25,7 +25,7 @@ var Utils = (function() {
                                 simultaneousUploads: 4,
                                 testChunks: false,
                                 throttleProgressCallbacks: 1,
-                                maxFileSize: 1 * 1024 * 1024 * 1024 // 1 GB max
+                                maxFileSize: 3 * 1024 * 1024 * 1024 // 3 GB max
                             });
     }
 


### PR DESCRIPTION
…ead of 1gb as the new MRI machine creates scans with a larger output size